### PR TITLE
Fix typo in success message after registration

### DIFF
--- a/frontend_v2/src/components/shared/SuccessForm.tsx
+++ b/frontend_v2/src/components/shared/SuccessForm.tsx
@@ -7,7 +7,7 @@ export default function SuccessForm() {
         <CheckCircle className="w-16 h-16 md:w-20 md:h-20 text-green-500 mb-3 animate-bounce" />
         <h1 className="text-lg md:text-xl font-semibold">Thank You!</h1>
         <p className="text-sm md:text-base">
-          You submission has been sent successfully
+          Your submission has been sent successfully
         </p>
       </div>
     </div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "OldWeb3bridgewebsite",
+  "name": "web3bridgewebsite",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "web3bridgewebsite",
+  "name": "OldWeb3bridgewebsite",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {}


### PR DESCRIPTION
Corrected 'You' to 'Your' in the success message displayed after registration.